### PR TITLE
Always initialize slices when converting keys to strings

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -13,7 +13,7 @@ func convertKeysToStrings(item interface{}) interface{} {
 		return newMap
 
 	case []interface{}:
-		var newArray []interface{}
+		newArray := make([]interface{}, 0)
 		for _, value := range typedDatas {
 			newArray = append(newArray, convertKeysToStrings(value))
 		}


### PR DESCRIPTION
Fixes the problem where empty slices were being serialized as `null`.
